### PR TITLE
Client python changes

### DIFF
--- a/client_python/BUILD
+++ b/client_python/BUILD
@@ -118,6 +118,28 @@ grakn_py_merge_sourcetrees(
     proto_src = ":generated_py_lib",
 )
 
+py_library(
+    name = "pypi_grpcio",
+    deps = [
+      requirement("grpcio")
+    ]
+)
+
+py_library(
+    name = "pypi_protobuf",
+    deps = [
+      requirement("protobuf")
+    ]
+)
+
+py_library(
+    name = "pypi_dependencies",
+    deps = [
+        ":pypi_grpcio",
+        ":pypi_protobuf"
+    ]
+)
+
 
 py_test(
     name = "test_concept",
@@ -125,8 +147,7 @@ py_test(
     data = [":dist"],
     imports = ["dist.zip"],
     deps = [
-        requirement("grpcio"),
-        requirement("protobuf"),
+        ":pypi_dependencies"
     ]
 )
 
@@ -136,8 +157,7 @@ py_test(
     data = [":dist"],
     imports = ["dist.zip"],
     deps = [
-        requirement("grpcio"),
-        requirement("protobuf"),
+        ":pypi_dependencies"
     ]
 )
 
@@ -147,8 +167,7 @@ py_test(
     data = [":dist"],
     imports = ["dist.zip"],
     deps = [
-        requirement("grpcio"),
-        requirement("protobuf"),
+        ":pypi_dependencies"
     ]
 )
 

--- a/client_python/lib.bzl
+++ b/client_python/lib.bzl
@@ -1,4 +1,4 @@
-def _impl(ctx):
+def _grakn_py_merge_sourcetrees_impl(ctx):
     args = [ctx.outputs.out.path] + [f.path for f in ctx.files.py_src + ctx.files.proto_src]
     ctx.actions.run(inputs = ctx.attr.py_src.files + ctx.attr.proto_src.files,
         outputs = [ctx.outputs.out],
@@ -10,7 +10,7 @@ def _impl(ctx):
 
 
 grakn_py_merge_sourcetrees = rule(
-    implementation = _impl,
+    implementation = _grakn_py_merge_sourcetrees_impl,
     attrs = {
         "py_src": attr.label(),
         "proto_src": attr.label(),

--- a/client_python/requirements.txt
+++ b/client_python/requirements.txt
@@ -1,2 +1,2 @@
-grpcio
-protobuf
+grpcio==1.13.0
+protobuf==3.6.0

--- a/dependencies/compilers/dependencies.bzl
+++ b/dependencies/compilers/dependencies.bzl
@@ -41,7 +41,7 @@ def grpc_dependencies():
 def python_dependencies():
     native.git_repository(
         name = "io_bazel_rules_python",
-        remote = "https://github.com/jkinkead/rules_python.git",
-        commit = "07785fcc2bd7b99f84954f2365f236e5bfe632f7",
-        sha256 = "43dba49e83b6ebb74545dc72e36b06ef8478e2954e2222936a0348be7307036b"
+        remote = "https://github.com/graknlabs/rules_python.git",
+        commit = "ab4ab0e2cd735bfcc160b3c6cb331c4bbef2d0cd",
+        sha256 = "86c06d8dfc2c327d00eea0520d5145f2a33f06df1918316c686557a703370689"
     )

--- a/dependencies/compilers/dependencies.bzl
+++ b/dependencies/compilers/dependencies.bzl
@@ -42,6 +42,6 @@ def python_dependencies():
     native.git_repository(
         name = "io_bazel_rules_python",
         remote = "https://github.com/graknlabs/rules_python.git",
-        commit = "ab4ab0e2cd735bfcc160b3c6cb331c4bbef2d0cd",
-        sha256 = "86c06d8dfc2c327d00eea0520d5145f2a33f06df1918316c686557a703370689"
+        commit = "abd475a72ae6a098cc9f859eb435dddd992bc884",
+        sha256 = "fe468b9396ef5c933679e1a5d846f777d0ea4731927df2149e5a01b328afd9b6"
     )


### PR DESCRIPTION
# Why is this PR needed?

Improves how `client-python` impacts other targets

# What does the PR do?
Commit messages should be pretty descriptive but this is the gist:

* Lock versions of PyPI dependencies
* Rename rule implementation function name to match standard
* Use vendored-in `rules_proto` with support of Python 3
* Warn if Python 3 is absent but keep the ability to build everythin

# Does it break backwards compatibility?

Nope

# List of future improvements not on this PR
