### PR TITLE
Unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ bazel-*
 .idea/
 *.iml
 *.geany
+.ijwb/
 
 # VS Code files #
 .vscode/

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -50,7 +50,7 @@ load("//dependencies/compilers:dependencies.bzl", "grpc_dependencies", "python_d
 grpc_dependencies()
 python_dependencies()
 
-# Python PIP dependencies
+## Python PIP dependencies
 load("@io_bazel_rules_python//python:pip.bzl", "pip_repositories", "pip3_import")
 pip_repositories()
 pip3_import(

--- a/grakn-graql/BUILD
+++ b/grakn-graql/BUILD
@@ -85,18 +85,14 @@ java_test(
 java_test(
     name = "InMemorySessionTest",
     srcs = ["src/test/java/ai/grakn/InMemorySessionTest.java"],
-    deps = [":grakn-graql"] + [
-        "//dependencies/maven/artifacts/org/apache/tinkerpop:gremlin-core"
-    ],
+    deps = [":grakn-graql", "//dependencies/maven/artifacts/org/apache/tinkerpop:gremlin-core"],
     size = "small"
 )
 
 java_test(
     name = "GraknTxOperationExceptionTest",
     srcs = ["src/test/java/ai/grakn/exception/GraknTxOperationExceptionTest.java"],
-    deps = [":grakn-graql"] + [
-        "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
-    ],
+    deps = [":grakn-graql","//dependencies/maven/artifacts/org/hamcrest:hamcrest-library"],
     size = "small"
 )
 
@@ -104,19 +100,17 @@ java_test(
     name = "TxFactoryBuilderTest",
     srcs = ["src/test/java/ai/grakn/factory/TxFactoryBuilderTest.java"],
     resources = ["src/test/resources/inmemory-graph.properties"],
-    deps = [":grakn-graql"] + [
-        "//dependencies/maven/artifacts/org/mockito:mockito-core",
-    ],
+    deps = [":grakn-graql","//dependencies/maven/artifacts/org/mockito:mockito-core"],
     size = "small"
 )
 
 java_test(
     name = "GraknTxTinkerFactoryTest",
     srcs = ["src/test/java/ai/grakn/factory/GraknTxTinkerFactoryTest.java"],
-    deps = [":grakn-graql"] + [
-        "//dependencies/maven/artifacts/org/mockito:mockito-core",
-        "//dependencies/maven/artifacts/org/apache/tinkerpop:tinkergraph-gremlin",
+    deps = [":grakn-graql", "//dependencies/maven/artifacts/org/mockito:mockito-core",
+        "//dependencies/maven/artifacts/org/apache/tinkerpop:tinkergraph-gremlin"
     ],
+    resources = ["src/test/resources/inmemory-graph.properties"],
     size = "small"
 )
 

--- a/grakn-graql/src/main/java/ai/grakn/core/server/GraknConfig.java
+++ b/grakn-graql/src/main/java/ai/grakn/core/server/GraknConfig.java
@@ -30,8 +30,10 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Properties;
@@ -71,11 +73,21 @@ public class GraknConfig {
     }
 
     public static GraknConfig read(File path) {
+        InputStream inputStream = null;
+        try {
+            inputStream = new FileInputStream(path);
+        } catch (FileNotFoundException e) {
+            LOG.error("Could not load engine properties from {}", path, e);
+        }
+        return read(inputStream);
+    }
+
+    public static GraknConfig read(InputStream inputStream){
         Properties prop = new Properties();
-        try (FileInputStream inputStream = new FileInputStream(path)) {
+        try {
             prop.load(inputStream);
         } catch (IOException e) {
-            LOG.error("Could not load engine properties from {}", path, e);
+            LOG.error("Could not load engine properties from input stream provided", e);
         }
         LOG.info("Project directory in use: {}", PROJECT_PATH);
         LOG.info("Configuration file in use: {}", CONFIG_FILE_PATH);

--- a/grakn-graql/src/main/java/ai/grakn/core/server/GraknConfig.java
+++ b/grakn-graql/src/main/java/ai/grakn/core/server/GraknConfig.java
@@ -68,14 +68,16 @@ public class GraknConfig {
     }
 
     public static GraknConfig create() {
-        if(defaultConfig == null){ defaultConfig = GraknConfig.read(CONFIG_FILE_PATH.toFile()); }
+        if(defaultConfig == null){
+            defaultConfig = GraknConfig.read(CONFIG_FILE_PATH);
+        }
         return defaultConfig;
     }
 
-    public static GraknConfig read(File path) {
+    public static GraknConfig read(Path path) {
         InputStream inputStream = null;
         try {
-            inputStream = new FileInputStream(path);
+            inputStream = new FileInputStream(path.toString());
         } catch (FileNotFoundException e) {
             LOG.error("Could not load engine properties from {}", path, e);
         }

--- a/grakn-graql/src/test/java/ai/grakn/factory/GraknTxTinkerFactoryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/factory/GraknTxTinkerFactoryTest.java
@@ -31,7 +31,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.io.File;
+import java.io.InputStream;
 
 import static ai.grakn.util.ErrorMessage.TRANSACTION_ALREADY_OPEN;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -42,9 +42,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class GraknTxTinkerFactoryTest {
-    private final File TEST_CONFIG_FILE = new File(this.getClass().getClassLoader().getResource("inmemory-graph.properties").getFile());
-    private final GraknConfig TEST_CONFIG = GraknConfig.read(TEST_CONFIG_FILE);
-    private final EmbeddedGraknSession session = mock(EmbeddedGraknSession.class);
+    private final static InputStream TEST_CONFIG_FILE = GraknTxTinkerFactoryTest.class.getClassLoader().getResourceAsStream("inmemory-graph.properties");
+    private final static GraknConfig TEST_CONFIG = GraknConfig.read(TEST_CONFIG_FILE);
+    private EmbeddedGraknSession session;
     private TxFactory tinkerGraphFactory;
 
 
@@ -53,6 +53,7 @@ public class GraknTxTinkerFactoryTest {
 
     @Before
     public void setupTinkerGraphFactory() {
+        session = mock(EmbeddedGraknSession.class);
         when(session.config()).thenReturn(TEST_CONFIG);
         tinkerGraphFactory = new TxFactoryTinker(session);
     }

--- a/grakn-graql/src/test/java/ai/grakn/factory/TxFactoryBuilderTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/factory/TxFactoryBuilderTest.java
@@ -26,13 +26,20 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
@@ -42,10 +49,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class TxFactoryBuilderTest {
-    private final EmbeddedGraknSession session = mock(EmbeddedGraknSession.class);
-    private final File TEST_CONFIG_FILE = new File(this.getClass().getClassLoader().getResource("inmemory-graph.properties").getFile());
+    private final static EmbeddedGraknSession session = mock(EmbeddedGraknSession.class);
+    private final static InputStream TEST_CONFIG_FILE = TxFactoryBuilderTest.class.getClassLoader().getResourceAsStream("inmemory-graph.properties");
     private final static Keyspace KEYSPACE = Keyspace.of("keyspace");
-    private final GraknConfig TEST_CONFIG = GraknConfig.read(TEST_CONFIG_FILE);
+    private final static GraknConfig TEST_CONFIG = GraknConfig.read(TEST_CONFIG_FILE);
 
     @Rule
     public final ExpectedException expectedException = ExpectedException.none();

--- a/grakn-graql/src/test/resources/inmemory-graph.properties
+++ b/grakn-graql/src/test/resources/inmemory-graph.properties
@@ -64,3 +64,5 @@ test.start.embedded.components=true
 
 # How many threads to dedicate to background processes
 background-tasks.threads=1
+
+knowledge-base.schema-cache-timeout-ms=6000

--- a/server/BUILD
+++ b/server/BUILD
@@ -33,7 +33,6 @@ java_library(
     deps = [
         # Grakn Core dependencies
         "//grakn-graql:grakn-graql",
-        # "//dashboard:dashboard",
 
         # External dependencies
         "//dependencies/maven/artifacts/ch/qos/logback:logback-classic",
@@ -93,7 +92,9 @@ java_test(
 java_test(
     name = "RocksDbQueueTest",
     srcs = ["src/test/java/ai/grakn/engine/attribute/deduplicator/RocksDbQueueTest.java"],
-    deps = [":server"] + ["//grakn-graql"] + [
+    deps = [
+        ":server",
+        "//grakn-graql",
         "//dependencies/maven/artifacts/commons-io:commons-io",
         "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
     ],
@@ -103,16 +104,19 @@ java_test(
 java_test(
     name = "GraknConfigTest",
     srcs = ["src/test/java/ai/grakn/engine/config/GraknConfigTest.java"],
-    deps = [":server"] + ["//grakn-graql"],
+    deps = [":server", "//grakn-graql"],
+    resources = ["src/test/resources/inmemory-graph.properties"],
     size = "small"
 )
 
 java_test(
     name = "RequestsTest",
     srcs = ["src/test/java/ai/grakn/engine/controller/util/RequestsTest.java"],
-     deps = [":server"] + ["//grakn-graql"] + [
-            "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
-            "//dependencies/maven/artifacts/org/sharegov:mjson"
+     deps = [
+        ":server",
+        "//grakn-graql",
+        "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
+        "//dependencies/maven/artifacts/org/sharegov:mjson"
         ],
     size = "small"
 )

--- a/server/src/main/java/ai/grakn/core/server/bootup/EngineBootup.java
+++ b/server/src/main/java/ai/grakn/core/server/bootup/EngineBootup.java
@@ -66,7 +66,7 @@ public class EngineBootup {
         this.bootupProcessExecutor = bootupProcessExecutor;
         this.graknHome = graknHome;
         this.graknPropertiesPath = graknPropertiesPath;
-        this.graknProperties = GraknConfig.read(graknPropertiesPath.toFile());
+        this.graknProperties = GraknConfig.read(graknPropertiesPath);
     }
 
     /**

--- a/server/src/main/java/ai/grakn/core/server/bootup/StorageBootup.java
+++ b/server/src/main/java/ai/grakn/core/server/bootup/StorageBootup.java
@@ -66,7 +66,7 @@ public class StorageBootup {
 
     public StorageBootup(BootupProcessExecutor bootupProcessExecutor, Path graknHome, Path graknPropertiesPath) {
         this.graknHome = graknHome;
-        this.graknProperties = GraknConfig.read(graknPropertiesPath.toFile());
+        this.graknProperties = GraknConfig.read(graknPropertiesPath);
         this.bootupProcessExecutor = bootupProcessExecutor;
     }
 

--- a/server/src/main/java/ai/grakn/core/server/bootup/config/Configs.java
+++ b/server/src/main/java/ai/grakn/core/server/bootup/config/Configs.java
@@ -34,7 +34,7 @@ public class Configs {
     private static final String STORAGE_CONFIG_NAME = "cassandra.yaml";
 
     public static GraknConfig graknConfig(){
-        return GraknConfig.read(graknConfigPath().toFile());
+        return GraknConfig.read(graknConfigPath());
     }
 
     public static StorageConfig storageConfig(){

--- a/server/src/test/java/ai/grakn/engine/config/GraknConfigTest.java
+++ b/server/src/test/java/ai/grakn/engine/config/GraknConfigTest.java
@@ -25,16 +25,18 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.io.InputStream;
+
 import static junit.framework.TestCase.assertNotNull;
 
 /**
  * Testing the {@link GraknConfig} class
  *
- * @author alexandraorth
  */
 public class GraknConfigTest {
 
-    private static GraknConfig configuration = GraknConfig.create();
+    private final static InputStream TEST_CONFIG_FILE = GraknConfigTest.class.getClassLoader().getResourceAsStream("inmemory-graph.properties");
+    private final static GraknConfig configuration = GraknConfig.read(TEST_CONFIG_FILE);
 
     @Rule
     public final ExpectedException exception = ExpectedException.none();

--- a/server/src/test/resources/inmemory-graph.properties
+++ b/server/src/test/resources/inmemory-graph.properties
@@ -1,0 +1,68 @@
+#
+# GRAKN.AI - THE KNOWLEDGE GRAPH
+# Copyright (C) 2018 Grakn Labs Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+# Directory in which server data will be stored
+data-dir=db/
+
+# Internal Factory Definition
+knowledge-base.mode=in-memory
+knowledge-base.analytics=in-memory
+
+# Logging
+log.dirs=./logs/
+log.level=INFO
+
+#Spark Config
+server.port=4567
+server.host=0.0.0.0
+server.static-file-dir=./services/assets/
+webserver.threads=64
+grpc.port=48555
+
+
+#Redis Config
+queue.host=localhost:6379
+post-processor.pool-size=32
+post-processor.delay=300
+queue.pool-size=32
+queue.sentinel.master=graknmaster
+queue.sentinel.host=
+
+####################################
+# Grakn Config                     #
+####################################
+#Keyspace to be used when none is provided
+knowledge-base.default-keyspace=grakntest
+
+#A Type will be sharded when this Thing threshold is hit
+knowledge-base.sharding-threshold=100000
+
+# Graph schema caching
+knowledge-base.schema-cache-timeout-ms=600000
+
+
+#Loader Config
+loader.threads=1
+
+# whether to start an embedded engine, cassandra and redis for tests
+test.start.embedded.components=true
+
+# How many threads to dedicate to background processes
+background-tasks.threads=1
+
+knowledge-base.schema-cache-timeout-ms=6000


### PR DESCRIPTION
# Why is this PR needed?

Unit tests were failing when trying to create file out of `inmemory-graph.properties`
This is because Bazel packages the resources files inside the `.jar` archive that contains generated test classes.

All Java unit tests are now Passing

# What does the PR do?

Read config file as a stream instead of File.

# Does it break backwards compatibility?

no

# List of future improvements not on this PR

no