### PR TITLE
Reenable python in bazel workspace file

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -51,14 +51,14 @@ grpc_dependencies()
 python_dependencies()
 
 ## Python PIP dependencies
-#load("@io_bazel_rules_python//python:pip.bzl", "pip_repositories", "pip3_import")
-#pip_repositories()
-#pip3_import(
-#    name = "python_grakn_deps",
-#    requirements = "//client_python:requirements.txt",
-#)
-#load("@python_grakn_deps//:requirements.bzl", "pip_install")
-#pip_install()
+load("@io_bazel_rules_python//python:pip.bzl", "pip_repositories", "pip3_import")
+pip_repositories()
+pip3_import(
+    name = "python_grakn_deps",
+    requirements = "//client_python:requirements.txt",
+)
+load("@python_grakn_deps//:requirements.bzl", "pip_install")
+pip_install()
 
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", com_github_grpc_grpc_bazel_grpc_deps = "grpc_deps")
 com_github_grpc_grpc_bazel_grpc_deps()


### PR DESCRIPTION
# Why is this PR needed?
During the process of merging https://github.com/haikalpribadi/grakn/pull/19, the Python dependencies was disabled for the sake of making the build step pass (otherwise, the build will fail due to issue https://github.com/graknlabs/grakn/issues/4495).

Now that the PR has been merged, re-enable the Python dependency. It will cause the build to fail again on CircleCI until https://github.com/graknlabs/grakn/issues/4495 is fixed.

# What does the PR do?
Reenable python in bazel workspace file

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A