### PR TITLE
Bazel init test end to end attribute deduplicator

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -51,15 +51,15 @@ grpc_dependencies()
 python_dependencies()
 node_dependencies()
 
-## Python PIP dependencies
-load("@io_bazel_rules_python//python:pip.bzl", "pip_repositories", "pip3_import")
-pip_repositories()
-pip3_import(
-    name = "python_grakn_deps",
-    requirements = "//dependencies/pypi:requirements.txt",
-)
-load("@python_grakn_deps//:requirements.bzl", "pip_install")
-pip_install()
+### Python PIP dependencies
+#load("@io_bazel_rules_python//python:pip.bzl", "pip_repositories", "pip3_import")
+#pip_repositories()
+#pip3_import(
+#    name = "python_grakn_deps",
+#    requirements = "//dependencies/pypi:requirements.txt",
+#)
+#load("@python_grakn_deps//:requirements.bzl", "pip_install")
+#pip_install()
 
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", com_github_grpc_grpc_bazel_grpc_deps = "grpc_deps")
 com_github_grpc_grpc_bazel_grpc_deps()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -51,15 +51,15 @@ grpc_dependencies()
 python_dependencies()
 node_dependencies()
 
-### Python PIP dependencies
-#load("@io_bazel_rules_python//python:pip.bzl", "pip_repositories", "pip3_import")
-#pip_repositories()
-#pip3_import(
-#    name = "python_grakn_deps",
-#    requirements = "//dependencies/pypi:requirements.txt",
-#)
-#load("@python_grakn_deps//:requirements.bzl", "pip_install")
-#pip_install()
+## Python PIP dependencies
+load("@io_bazel_rules_python//python:pip.bzl", "pip_repositories", "pip3_import")
+pip_repositories()
+pip3_import(
+    name = "python_grakn_deps",
+    requirements = "//dependencies/pypi:requirements.txt",
+)
+load("@python_grakn_deps//:requirements.bzl", "pip_install")
+pip_install()
 
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", com_github_grpc_grpc_bazel_grpc_deps = "grpc_deps")
 com_github_grpc_grpc_bazel_grpc_deps()

--- a/test-end-to-end/BUILD
+++ b/test-end-to-end/BUILD
@@ -4,5 +4,6 @@ test_suite(
         "//test-end-to-end/distribution:grakn-graql-commands-e2e",
         "//test-end-to-end/distribution:grakn-graql-commands-with-a-running-grakn-e2e",
         "//test-end-to-end/client_java:client-java-e2e",
+        "//test-end-to-end/attribute_deduplicator:attribute-deduplicator-e2e"
     ]
 )

--- a/test-end-to-end/attribute_deduplicator/AttributeDeduplicatorE2E.java
+++ b/test-end-to-end/attribute_deduplicator/AttributeDeduplicatorE2E.java
@@ -1,0 +1,181 @@
+package ai.grakn.attribute_deduplicator;
+
+
+import ai.grakn.GraknTxType;
+import ai.grakn.Keyspace;
+import ai.grakn.client.Grakn;
+import ai.grakn.concept.AttributeType;
+import ai.grakn.graql.answer.ConceptMap;
+import ai.grakn.util.SimpleURI;
+import org.apache.commons.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.RocksIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.zeroturnaround.exec.ProcessExecutor;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeoutException;
+
+import static ai.grakn.attribute_deduplicator.AttributeDeduplicatorE2EConstants.GRAKN_UNZIPPED_DIRECTORY;
+import static ai.grakn.attribute_deduplicator.AttributeDeduplicatorE2EConstants.assertGraknRunning;
+import static ai.grakn.attribute_deduplicator.AttributeDeduplicatorE2EConstants.assertGraknStopped;
+import static ai.grakn.attribute_deduplicator.AttributeDeduplicatorE2EConstants.assertZipExists;
+import static ai.grakn.attribute_deduplicator.AttributeDeduplicatorE2EConstants.unzipGrakn;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static ai.grakn.graql.Graql.count;
+import static ai.grakn.graql.Graql.label;
+import static ai.grakn.graql.Graql.var;
+
+public class AttributeDeduplicatorE2E {
+    private static Logger LOG = LoggerFactory.getLogger(AttributeDeduplicatorE2E.class);
+    private Grakn localhostGrakn = new Grakn(new SimpleURI("localhost:48555"));
+    private Path queuePath = GRAKN_UNZIPPED_DIRECTORY.resolve("db").resolve("queue");
+
+    private static ProcessExecutor commandExecutor = new ProcessExecutor()
+            .directory(GRAKN_UNZIPPED_DIRECTORY.toFile())
+            .redirectOutput(System.out)
+            .redirectError(System.err)
+            .readOutput(true);
+
+    @BeforeClass
+    public static void setup_prepareDistribution() throws IOException, InterruptedException, TimeoutException {
+        assertZipExists();
+        unzipGrakn();
+        assertGraknStopped();
+        commandExecutor.command("./grakn-core", "server", "start").execute();
+        assertGraknRunning();
+    }
+
+    @AfterClass
+    public static void cleanup_cleanupDistribution() throws IOException, InterruptedException, TimeoutException {
+        commandExecutor.command("./grakn-core", "server", "stop").execute();
+        assertGraknStopped();
+        FileUtils.deleteDirectory(GRAKN_UNZIPPED_DIRECTORY.toFile());
+    }
+
+    @Test
+    public void shouldDeduplicateAttributes() throws RocksDBException, InterruptedException, ExecutionException {
+        int numOfUniqueNames = 10;
+        int numOfDuplicatesPerName = 673;
+        ExecutorService executorServiceForParallelInsertion = Executors.newFixedThreadPool(8);
+
+        LOG.info("initiating the shouldDeduplicate10AttributesWithDuplicates test...");
+        try (Grakn.Session session = localhostGrakn.session(Keyspace.of("attribute_deduplicator_e2e"))) {
+            // insert 10 attributes, each with 100 duplicates
+            LOG.info("defining the schema...");
+            defineParentChildSchema(session);
+            LOG.info("inserting " + numOfUniqueNames + " unique attributes with " + numOfDuplicatesPerName + " duplicates per attribute....");
+            insertNameShuffled(session, numOfUniqueNames, numOfDuplicatesPerName, executorServiceForParallelInsertion);
+
+            // wait until queue is empty
+            LOG.info("names and duplicates have been inserted. waiting for the deduplication to finish...");
+            long timeoutMs = 60000;
+            long pollFrequencyMs = 2000;
+            waitUntilAllAttributesDeduplicated(timeoutMs, pollFrequencyMs);
+            LOG.info("deduplication has finished.");
+
+            // verify deduplicated attributes
+            LOG.info("verifying the number of attributes");
+            int countAfterDeduplication = countTotalNames(session);
+            assertThat(countAfterDeduplication, equalTo(numOfUniqueNames));
+            LOG.info("test completed successfully. there are " + countAfterDeduplication + " unique names found");
+        }
+    }
+
+    private void defineParentChildSchema(Grakn.Session session) {
+        try (Grakn.Transaction tx = session.transaction(GraknTxType.WRITE)) {
+            List<ConceptMap> answer = tx.graql().define(
+                    label("name").sub("attribute").datatype(AttributeType.DataType.STRING),
+                    label("parent").sub("role"),
+                    label("child").sub("role"),
+                    label("person").sub("entity").has("name").plays("parent").plays("child"),
+                    label("parentchild").sub("relationship").relates("parent").relates("child")
+            ).execute();
+            tx.commit();
+        }
+    }
+
+    private static void insertNameShuffled(Grakn.Session session, int nameCount, int duplicatePerNameCount, ExecutorService executorService)
+            throws ExecutionException, InterruptedException {
+
+        List<String> duplicatedNames = new ArrayList<>();
+        for (int i = 0; i < nameCount; ++i) {
+            for (int j = 0; j < duplicatePerNameCount; ++j) {
+                String name = "lorem ipsum dolor sit amet " + i;
+                duplicatedNames.add(name);
+            }
+        }
+
+        Collections.shuffle(duplicatedNames, new Random(1));
+
+        List<CompletableFuture<Void>> asyncInsertions = new ArrayList<>();
+        for (String name: duplicatedNames) {
+            CompletableFuture<Void> asyncInsert = CompletableFuture.supplyAsync(() -> {
+                try (Grakn.Transaction tx = session.transaction(GraknTxType.WRITE)) {
+                    List<ConceptMap> answer = tx.graql().insert(var().isa("name").val(name)).execute();
+                    tx.commit();
+                }
+                return null;
+            }, executorService);
+            asyncInsertions.add(asyncInsert);
+        }
+
+        CompletableFuture.allOf(asyncInsertions.toArray(new CompletableFuture[] {})).get();
+    }
+
+    private void waitUntilAllAttributesDeduplicated(long timeoutMs, long pollFrequencyMs) throws RocksDBException, InterruptedException {
+        long startMs = System.currentTimeMillis();
+        int queueSize = countRemainingItemsInQueue(queuePath);
+        while (queueSize > 0) {
+            LOG.info("deduplication in progress. there are " + queueSize + " attributes left to process.");
+            Thread.sleep(pollFrequencyMs);
+            long elapsedMs = System.currentTimeMillis() - startMs;
+            if (elapsedMs > timeoutMs) {
+                String message = "waitUntilAllAttributesDeduplicated - Timeout of '" + timeoutMs + "ms has been exceeded. There are '" + queueSize + "' items remaining in the queue.";
+                throw new RuntimeException(message);
+            }
+            queueSize = countRemainingItemsInQueue(queuePath);
+        }
+    }
+
+    /**
+     * Count the number of elements in the queue
+     *
+     * @param queuePath the queue to be checked
+     * @return the number of elements in the queue
+     */
+    private int countRemainingItemsInQueue(Path queuePath) throws RocksDBException {
+        RocksDB queue = RocksDB.openReadOnly(new Options(), queuePath.toAbsolutePath().toString());
+        RocksIterator it = queue.newIterator();
+        it.seekToFirst();
+        int count = 0;
+        while (it.isValid()) {
+            it.next();
+            count++;
+        }
+        queue.close();
+        return count;
+    }
+
+    private int countTotalNames(Grakn.Session session) {
+        try (Grakn.Transaction tx = session.transaction(GraknTxType.READ)) {
+            return tx.graql().match(var("x").isa("name")).aggregate(count()).execute().get(0).number().intValue();
+        }
+    }
+}

--- a/test-end-to-end/attribute_deduplicator/AttributeDeduplicatorE2EConstants.java
+++ b/test-end-to-end/attribute_deduplicator/AttributeDeduplicatorE2EConstants.java
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package ai.grakn.distribution;
+package ai.grakn.attribute_deduplicator;
 
 import ai.grakn.GraknConfigKey;
 import ai.grakn.core.server.GraknConfig;
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeoutException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-public class DistributionE2EConstants {
+public class AttributeDeduplicatorE2EConstants {
     public static final Path GRAKN_TARGET_DIRECTORY = Paths.get("dist");
     public static final Path ZIP_FULLPATH = Paths.get(GRAKN_TARGET_DIRECTORY.toString(), "grakn-core-all.zip");
     public static final Path GRAKN_UNZIPPED_DIRECTORY = Paths.get(GRAKN_TARGET_DIRECTORY.toString(), "distribution test", "grakn-core-all");

--- a/test-end-to-end/attribute_deduplicator/BUILD
+++ b/test-end-to-end/attribute_deduplicator/BUILD
@@ -1,0 +1,15 @@
+java_test(
+    name = "attribute-deduplicator-e2e",
+    test_class = "ai.grakn.attribute_deduplicator.AttributeDeduplicatorE2E",
+    srcs = ["AttributeDeduplicatorE2E.java", "AttributeDeduplicatorE2EConstants.java"],
+    deps = [
+        "//grakn-graql:grakn-graql",
+        "//client-java:client-java",
+        "//dependencies/maven/artifacts/commons-io:commons-io",
+        "//dependencies/maven/artifacts/org/rocksdb:rocksdbjni",
+        "//dependencies/maven/artifacts/org/zeroturnaround:zt-exec",
+        "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
+        "//dependencies/maven/artifacts/org/slf4j:slf4j-api"
+    ],
+    data = ["//:distribution-all"]
+)

--- a/test-end-to-end/distribution/BUILD
+++ b/test-end-to-end/distribution/BUILD
@@ -20,8 +20,7 @@ java_test(
         "//grakn-graql:grakn-graql",
         "//dependencies/maven/artifacts/commons-io:commons-io",
         "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
-        "//dependencies/maven/artifacts/org/zeroturnaround:zt-exec",
-        "//dependencies/maven/artifacts/javax/ws/rs:jsr311-api"
+        "//dependencies/maven/artifacts/org/zeroturnaround:zt-exec"
     ],
     data = ["//:distribution-all"]
 )


### PR DESCRIPTION
# Why is this PR needed?
Added `//test-end-to-end:attribute_deduplicator`

# What does the PR do?

# Does it break backwards compatibility?

# List of future improvements not on this PR
