### PR TITLE
Migrate client-python to Python 2

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -52,9 +52,9 @@ python_dependencies()
 node_dependencies()
 
 ## Python PIP dependencies
-load("@io_bazel_rules_python//python:pip.bzl", "pip_repositories", "pip3_import")
+load("@io_bazel_rules_python//python:pip.bzl", "pip_repositories", "pip_import")
 pip_repositories()
-pip3_import(
+pip_import(
     name = "python_grakn_deps",
     requirements = "//dependencies/pypi:requirements.txt",
 )

--- a/client_python/BUILD
+++ b/client_python/BUILD
@@ -41,33 +41,46 @@ py_library(
     ]),
     deps = [
         requirement("protobuf"),
-        requirement("grpcio")
+        requirement("grpcio"),
+        requirement("six"),
     ]
 )
 
 py_test(
     name = "test_concept",
-    srcs = ["tests/integration/test_concept.py"],
+    srcs = [
+        "tests/integration/base.py",
+        "tests/integration/test_concept.py"
+    ],
     deps = [
-        ":client_python"
+        ":client_python",
+        requirement("forbiddenfruit")
     ],
     imports = [".", "./client_python_proto"]
 )
 
 py_test(
     name = "test_grakn",
-    srcs = ["tests/integration/test_grakn.py"],
+    srcs = [
+        "tests/integration/base.py",
+        "tests/integration/test_grakn.py"
+    ],
     deps = [
-        ":client_python"
+        ":client_python",
+        requirement("forbiddenfruit")
     ],
     imports = [".", "./client_python_proto"]
 )
 
 py_test(
     name = "test_keyspace",
-    srcs = ["tests/integration/test_keyspace.py"],
+    srcs = [
+        "tests/integration/base.py",
+        "tests/integration/test_keyspace.py"
+    ],
     deps = [
-        ":client_python"
+        ":client_python",
+        requirement("forbiddenfruit")
     ],
     imports = [".", "./client_python_proto"]
 )

--- a/client_python/grakn/__init__.py
+++ b/client_python/grakn/__init__.py
@@ -32,9 +32,10 @@ class Grakn(object):
         self._keyspace_service = KeyspaceService(self.uri, credentials)
         self.credentials = credentials
 
-    def session(self, keyspace: str):
+    def session(self, keyspace):
         """ Open a session for a specific  keyspace. Can be used as `with Grakn('localhost:48555').session(keyspace='test') as session: ... ` or as normal assignment"""
         return Session(self.uri, keyspace, self.credentials)
+    session.__annotations__ = {'keyspace': str}
 
     def keyspaces(self):
         return self._keyspace_service
@@ -43,7 +44,7 @@ class Grakn(object):
 class Session(object):
     """ A session for a Grakn instance and a specific keyspace """
 
-    def __init__(self, uri: str, keyspace: str, credentials):
+    def __init__(self, uri, keyspace, credentials):
 
         self.keyspace = keyspace
         self.uri = uri
@@ -52,6 +53,7 @@ class Session(object):
         self._channel = grpc.insecure_channel(uri)
         self._stub = SessionServiceStub(self._channel)
         self._closed = False
+    __init__.__annotations__ = {'uri': str, 'keyspace': str}
 
     def transaction(self, tx_type):
         """ Open a transaction to Grakn on this keyspace
@@ -90,8 +92,9 @@ class Session(object):
 class Transaction(object):
     """ Presents the Grakn interface to the user, actual work with GRPC happens in TransactionService """
 
-    def __init__(self, transaction_service: TransactionService):
+    def __init__(self, transaction_service):
         self._tx_service = transaction_service
+    __init__.__annotations__ = {'transaction_service': TransactionService}
 
     def __enter__(self):
         return self
@@ -105,9 +108,10 @@ class Transaction(object):
             #print("Closing Transaction due to exception: {0} \n traceback: \n {1}".format(type, tb))
             return False
 
-    def query(self, query: str, infer=True):
+    def query(self, query, infer=True):
         """ Execute a Graql query, inference is optionally enabled """
         return self._tx_service.query(query, infer)
+    query.__annotations__ = {'query': str}
 
     def commit(self):
         """ Commit and close this transaction, persisting changes to Grakn """
@@ -122,13 +126,15 @@ class Transaction(object):
         """ Check if this transaction is closed """
         return self._tx_service.is_closed()
 
-    def get_concept(self, concept_id: str):
+    def get_concept(self, concept_id):
         """ Retrieve a concept by Concept ID (string) """
         return self._tx_service.get_concept(concept_id)
+    get_concept.__annotations__ = {'concept_id': str}
 
-    def get_schema_concept(self, label: str): 
+    def get_schema_concept(self, label):
         """ Retrieve a schema concept by its label (eg. those defined using `define` or tx.put...() """
         return self._tx_service.get_schema_concept(label)
+    get_schema_concept.__annotations__ = {'label': str}
 
     def get_attributes_by_value(self, attribute_value, data_type):
         """ Retrieve atttributes with a specific value and datatype
@@ -138,26 +144,31 @@ class Transaction(object):
         """
         return self._tx_service.get_attributes_by_value(attribute_value, data_type)
 
-    def put_entity_type(self, label: str):
+    def put_entity_type(self, label):
         """ Define a new entity type with the given label """
         return self._tx_service.put_entity_type(label)
+    put_entity_type.__annotations__ = {'label': str}
 
-    def put_relationship_type(self, label: str):
+    def put_relationship_type(self, label):
         """ Define a new relationship type with the given label """
         return self._tx_service.put_relationship_type(label)
+    put_relationship_type.__annotations__ = {'label': str}
 
-    def put_attribute_type(self, label: str, data_type):
+    def put_attribute_type(self, label, data_type):
         """ Define a new attribute type with the given label and data type 
 
         :param str label: the label of the attribute type
         :param grakn.DataType data_type: the data type of the value to be stored, as given by the grakn.DataType enum
         """
         return self._tx_service.put_attribute_type(label, data_type)
+    put_attribute_type.__annotations__ = {'label': str}
 
-    def put_role(self, label: str):
+    def put_role(self, label):
         """ Define a role with the given label """
         return self._tx_service.put_role(label)
+    put_role.__annotations__ = {'label': str}
 
-    def put_rule(self, label: str, when: str, then: str):
+    def put_rule(self, label, when, then):
         """ Define a new rule with the given label, when and then clauses """
         return self._tx_service.put_rule(label, when, then)
+    put_rule.__annotations__ = {'label': str, 'when': str, 'then': str}

--- a/client_python/grakn/service/Session/Concept/Concept.py
+++ b/client_python/grakn/service/Session/Concept/Concept.py
@@ -17,12 +17,9 @@
 # under the License.
 #
 
-from typing import Union, Optional
 
 from grakn.service.Session.util import enums
 from grakn.service.Session.util.RequestBuilder import RequestBuilder
-from grakn.service.Session.util import ResponseReader # must be imported this way to avoid circular import issue
-from grakn.service.Session.Concept import ConceptFactory
 from grakn.exception.GraknError import GraknError 
 
 
@@ -40,49 +37,60 @@ class Concept(object):
         method_response = self._tx_service.run_concept_method(self.id, del_request)
         return
 
-    def is_schema_concept(self) -> bool:
+    def is_schema_concept(self):
         """ Check if this concept is a schema concept """
         return isinstance(self, SchemaConcept)
+    is_schema_concept.__annotations__ = {'return': bool}
 
-    def is_type(self) -> bool:
+    def is_type(self):
         """ Check if this concept is a Type concept """
         return isinstance(self, Type)
+    is_type.__annotations__ = {'return': bool}
 
-    def is_thing(self) -> bool:
+    def is_thing(self):
         """ Check if this concept is a Thing concept """
         return isinstance(self, Thing)
+    is_thing.__annotations__ = {'return': bool}
 
-    def is_attribute_type(self) -> bool:
+    def is_attribute_type(self):
         """ Check if this concept is an AttributeType concept """
         return isinstance(self, AttributeType)
+    is_attribute_type.__annotations__ = {'return': bool}
 
-    def is_entity_type(self) -> bool:
+    def is_entity_type(self):
         """ Check if this concept is an EntityType concept """
         return isinstance(self, EntityType)
+    is_entity_type.__annotations__ = {'return': bool}
 
-    def is_relationship_type(self) -> bool:
+    def is_relationship_type(self):
         """ Check if this concept is a RelationshipType concept """
         return isinstance(self, RelationshipType)
+    is_relationship_type.__annotations__ = {'return': bool}
 
-    def is_role(self) -> bool:
+    def is_role(self):
         """ Check if this concept is a Role """
         return isinstance(self, Role)
+    is_role.__annotations__ = {'return': bool}
 
-    def is_rule(self) -> bool:
+    def is_rule(self):
         """ Check if this concept is a Rule concept """
         return isinstance(self, Rule)
+    is_rule.__annotations__ = {'return': bool}
 
-    def is_attribute(self) -> bool:
+    def is_attribute(self):
         """ Check if this concept is an Attribute concept """
         return isinstance(self, Attribute)
+    is_attribute.__annotations__ = {'return': bool}
 
-    def is_entity(self) -> bool:
+    def is_entity(self):
         """ Check if this concept is an Entity concept """
         return isinstance(self, Entity)
+    is_entity.__annotations__ = {'return': bool}
 
-    def is_relationship(self) -> bool:
+    def is_relationship(self):
         """ Check if this concept is a Relationship concept """
         return isinstance(self, Relationship)
+    is_relationship.__annotations__ = {'return': bool}
 
 
 class SchemaConcept(Concept):
@@ -121,6 +129,7 @@ class SchemaConcept(Concept):
             whichone = get_sup_response.WhichOneof('res')
             if whichone == 'schemaConcept':
                 grpc_schema_concept = get_sup_response.schemaConcept
+                from grakn.service.Session.Concept import ConceptFactory
                 concept = ConceptFactory.create_concept(self._tx_service, grpc_schema_concept)
                 return concept
             elif whichone == 'null':
@@ -137,11 +146,13 @@ class SchemaConcept(Concept):
         """ Retrieve the sub schema concepts of this schema concept, as an iterator """
         subs_req = RequestBuilder.ConceptMethod.SchemaConcept.subs()
         method_response = self._tx_service.run_concept_method(self.id, subs_req)
+        from grakn.service.Session.util import ResponseReader
+        from grakn.service.Session.Concept import ConceptFactory
         return ResponseReader.ResponseReader.iter_res_to_iterator(
                     self._tx_service,
                     method_response.schemaConcept_subs_iter.id,
                     lambda tx_serv, iter_res: 
-                        ConceptFactory.create_concept(tx_serv,  
+                        ConceptFactory.create_concept(tx_serv,
                         iter_res.conceptMethod_iter_res.schemaConcept_subs_iter_res.schemaConcept)
                     )
 
@@ -149,17 +160,19 @@ class SchemaConcept(Concept):
         """ Retrieve the all supertypes (direct and higher level) of this schema concept as an iterator """
         sups_req = RequestBuilder.ConceptMethod.SchemaConcept.sups()
         method_response = self._tx_service.run_concept_method(self.id, sups_req)
+        from grakn.service.Session.util import ResponseReader
+        from grakn.service.Session.Concept import ConceptFactory
         return ResponseReader.ResponseReader.iter_res_to_iterator(
                 self._tx_service,
                 method_response.schemaConcept_sups_iter.id,
                 lambda tx_serv, iter_res:
-                    ConceptFactory.create_concept(tx_serv, 
+                    ConceptFactory.create_concept(tx_serv,
                     iter_res.conceptMethod_iter_res.schemaConcept_sups_iter_res.schemaConcept)
                 )
  
 class Type(SchemaConcept):
 
-    def is_abstract(self, value: bool = None) -> Optional[bool]:
+    def is_abstract(self, value=None):
         """
         Get/Set whether this schema Type object is abstract.
         When used as a setter returns `self` 
@@ -173,11 +186,14 @@ class Type(SchemaConcept):
             set_abstract_req = RequestBuilder.ConceptMethod.Type.set_abstract(value)
             method_response = self._tx_service.run_concept_method(self.id, set_abstract_req)
             return self
+    is_abstract.__annotations__ = {'value': bool, 'return': bool}
 
     def attributes(self):
         """ Retrieve all attributes attached to this Type as an iterator """
         attributes_req = RequestBuilder.ConceptMethod.Type.attributes()
         method_response = self._tx_service.run_concept_method(self.id, attributes_req)
+        from grakn.service.Session.util import ResponseReader
+        from grakn.service.Session.Concept import ConceptFactory
         return ResponseReader.ResponseReader.iter_res_to_iterator(
                 self._tx_service,
                 method_response.type_attributes_iter.id,
@@ -190,6 +206,8 @@ class Type(SchemaConcept):
         """ Retrieve all instances of this Type as an iterator """
         instances_req = RequestBuilder.ConceptMethod.Type.instances()
         method_response = self._tx_service.run_concept_method(self.id, instances_req)
+        from grakn.service.Session.util import ResponseReader
+        from grakn.service.Session.Concept import ConceptFactory
         return ResponseReader.ResponseReader.iter_res_to_iterator(
                 self._tx_service,
                 method_response.type_instances_iter.id,
@@ -202,6 +220,8 @@ class Type(SchemaConcept):
         """ Retrieve iterator of roles played by this type """
         playing_req = RequestBuilder.ConceptMethod.Type.playing()
         method_response = self._tx_service.run_concept_method(self.id, playing_req)
+        from grakn.service.Session.util import ResponseReader
+        from grakn.service.Session.Concept import ConceptFactory
         return ResponseReader.ResponseReader.iter_res_to_iterator(
                 self._tx_service,
                 method_response.type_playing_iter.id,
@@ -238,6 +258,8 @@ class Type(SchemaConcept):
         """ Retrieve an iterator of attribute types that this Type uses as keys """
         keys_req = RequestBuilder.ConceptMethod.Type.keys()
         method_response = self._tx_service.run_concept_method(self.id, keys_req)
+        from grakn.service.Session.util import ResponseReader
+        from grakn.service.Session.Concept import ConceptFactory
         return ResponseReader.ResponseReader.iter_res_to_iterator(
                 self._tx_service,
                 method_response.type_keys_iter.id,
@@ -268,16 +290,18 @@ class EntityType(Type):
         create_req = RequestBuilder.ConceptMethod.EntityType.create()
         method_response = self._tx_service.run_concept_method(self.id, create_req)
         grpc_entity_concept = method_response.entityType_create_res.entity
+        from grakn.service.Session.Concept import ConceptFactory
         return ConceptFactory.create_concept(self._tx_service, grpc_entity_concept)
 
 class AttributeType(Type):
     
     def create(self, value):
         """ Create an instance with this AttributeType """
-        self_data_type: enums.DataType = self.data_type()
+        self_data_type = self.data_type()
         create_inst_req = RequestBuilder.ConceptMethod.AttributeType.create(value, self_data_type)
         method_response = self._tx_service.run_concept_method(self.id, create_inst_req)
         grpc_attribute_concept = method_response.attributeType_create_res.attribute
+        from grakn.service.Session.Concept import ConceptFactory
         return ConceptFactory.create_concept(self._tx_service, grpc_attribute_concept)
         
     def attribute(self, value):
@@ -288,6 +312,7 @@ class AttributeType(Type):
         response = method_response.attributeType_attribute_res
         whichone = response.WhichOneof('res')
         if whichone == 'attribute':
+            from grakn.service.Session.Concept import ConceptFactory
             return ConceptFactory.create_concept(self._tx_service, response.attribute)
         elif whichone == 'null':
             return None
@@ -313,7 +338,7 @@ class AttributeType(Type):
         else:
             raise GraknError("Unknown datatype response for AttributeType: {0}".format(whichone))
 
-    def regex(self, pattern: str = None):
+    def regex(self, pattern=None):
         """ Get or set regex """
         if pattern is None:
             get_regex_req = RequestBuilder.ConceptMethod.AttributeType.get_regex()
@@ -323,6 +348,7 @@ class AttributeType(Type):
             set_regex_req = RequestBuilder.ConceptMethod.AttributeType.set_regex(pattern)
             method_response = self._tx_service.run_concept_method(self.id, set_regex_req)
             return self
+    regex.__annotations__ = {'pattern': str}
 
 
 class RelationshipType(Type):
@@ -334,12 +360,15 @@ class RelationshipType(Type):
         create_rel_inst_req = RequestBuilder.ConceptMethod.RelationType.create()
         method_response = self._tx_service.run_concept_method(self.id, create_rel_inst_req)
         grpc_relationship_concept = method_response.relationType_create_res.relation
+        from grakn.service.Session.Concept import ConceptFactory
         return ConceptFactory.create_concept(self._tx_service, grpc_relationship_concept)
         
     def roles(self):
         """ Retrieve roles in this relationship schema type """
         get_roles = RequestBuilder.ConceptMethod.RelationType.roles()
         method_response = self._tx_service.run_concept_method(self.id, get_roles)
+        from grakn.service.Session.util import ResponseReader
+        from grakn.service.Session.Concept import ConceptFactory
         return ResponseReader.ResponseReader.iter_res_to_iterator(
                 self._tx_service,
                 method_response.relationType_roles_iter.id,
@@ -396,6 +425,8 @@ class Role(SchemaConcept):
         # NOTE: relations vs relationships here
         relations_req = RequestBuilder.ConceptMethod.Role.relations()
         method_response = self._tx_service.run_concept_method(self.id, relations_req)
+        from grakn.service.Session.util import ResponseReader
+        from grakn.service.Session.Concept import ConceptFactory
         return ResponseReader.ResponseReader.iter_res_to_iterator(
                 self._tx_service,
                 method_response.role_relations_iter.id,
@@ -407,6 +438,8 @@ class Role(SchemaConcept):
         """ Retrieve an iterator of entities that play this role """
         players_req = RequestBuilder.ConceptMethod.Role.players()
         method_response = self._tx_service.run_concept_method(self.id, players_req)
+        from grakn.service.Session.util import ResponseReader
+        from grakn.service.Session.Concept import ConceptFactory
         return ResponseReader.ResponseReader.iter_res_to_iterator(
                 self._tx_service,
                 method_response.role_players_iter.id,
@@ -417,16 +450,18 @@ class Role(SchemaConcept):
 
 class Thing(Concept):
 
-    def is_inferred(self) -> bool:
+    def is_inferred(self):
         """ Is this instance inferred """
         is_inferred_req = RequestBuilder.ConceptMethod.Thing.is_inferred()
         method_response = self._tx_service.run_concept_method(self.id, is_inferred_req)
         return method_response.thing_isInferred_res.inferred
+    is_inferred.__annotations__ = {'return': bool}
 
     def type(self):
         """ Get the type (schema concept) of this Thing """
         type_req = RequestBuilder.ConceptMethod.Thing.type()
         method_response = self._tx_service.run_concept_method(self.id, type_req)
+        from grakn.service.Session.Concept import ConceptFactory
         return ConceptFactory.create_concept(self._tx_service, method_response.thing_type_res.type)
 
     def relationships(self, *roles):
@@ -434,6 +469,8 @@ class Thing(Concept):
         # NOTE `relations` rather than `relationships`
         relations_req = RequestBuilder.ConceptMethod.Thing.relations(roles)
         method_response = self._tx_service.run_concept_method(self.id, relations_req)
+        from grakn.service.Session.util import ResponseReader
+        from grakn.service.Session.Concept import ConceptFactory
         return ResponseReader.ResponseReader.iter_res_to_iterator(
                 self._tx_service,
                 method_response.thing_relations_iter.id,
@@ -445,6 +482,8 @@ class Thing(Concept):
         """ Retrieve iterator of this Thing's attributes, filtered by optionally provided attribute types """
         attrs_req = RequestBuilder.ConceptMethod.Thing.attributes(attribute_types)
         method_response = self._tx_service.run_concept_method(self.id, attrs_req)
+        from grakn.service.Session.util import ResponseReader
+        from grakn.service.Session.Concept import ConceptFactory
         return ResponseReader.ResponseReader.iter_res_to_iterator(
                 self._tx_service,
                 method_response.thing_attributes_iter.id,
@@ -456,6 +495,8 @@ class Thing(Concept):
         """ Retrieve iterator of roles this Thing plays """
         roles_req = RequestBuilder.ConceptMethod.Thing.roles()
         method_response = self._tx_service.run_concept_method(self.id, roles_req)
+        from grakn.service.Session.util import ResponseReader
+        from grakn.service.Session.Concept import ConceptFactory
         return ResponseReader.ResponseReader.iter_res_to_iterator(
                 self._tx_service,
                 method_response.thing_roles_iter.id,
@@ -467,6 +508,8 @@ class Thing(Concept):
         """ Retrieve iterator of keys (i.e. actual attributes) of this Thing, filtered by the optionally provided attribute types """
         keys_req = RequestBuilder.ConceptMethod.Thing.keys(attribute_types)
         method_response = self._tx_service.run_concept_method(self.id, keys_req)
+        from grakn.service.Session.util import ResponseReader
+        from grakn.service.Session.Concept import ConceptFactory
         return ResponseReader.ResponseReader.iter_res_to_iterator(
                 self._tx_service,
                 method_response.thing_keys_iter.id,
@@ -499,12 +542,15 @@ class Attribute(Thing):
         value_req = RequestBuilder.ConceptMethod.Attribute.value()
         method_response = self._tx_service.run_concept_method(self.id, value_req)
         grpc_value_object = method_response.attribute_value_res.value
+        from grakn.service.Session.util import ResponseReader
         return ResponseReader.ResponseReader.from_grpc_value_object(grpc_value_object)
 
     def owners(self):
         """ Retrieve entities that have this attribute value """
         owners_req = RequestBuilder.ConceptMethod.Attribute.owners()
         method_response = self._tx_service.run_concept_method(self.id, owners_req)
+        from grakn.service.Session.util import ResponseReader
+        from grakn.service.Session.Concept import ConceptFactory
         return ResponseReader.ResponseReader.iter_res_to_iterator(
                 self._tx_service,
                 method_response.attribute_owners_iter.id,
@@ -524,10 +570,13 @@ class Relationship(Thing):
         # create the iterator to obtain all the pairs of (role, player)
         def to_pair(tx_service, iter_res):
             response = iter_res.conceptMethod_iter_res.relation_rolePlayersMap_iter_res
+            from grakn.service.Session.Concept import ConceptFactory
             role = ConceptFactory.create_concept(tx_service, response.role)
+            from grakn.service.Session.Concept import ConceptFactory
             player = ConceptFactory.create_concept(tx_service, response.player)
             return (role, player)
 
+        from grakn.service.Session.util import ResponseReader
         iterator = ResponseReader.ResponseReader.iter_res_to_iterator(
                     self._tx_service,
                     method_response.relation_rolePlayersMap_iter.id,
@@ -556,6 +605,8 @@ class Relationship(Thing):
         """ Retrieve role players filtered by roles """
         role_players_req = RequestBuilder.ConceptMethod.Relation.role_players(roles)
         method_response = self._tx_service.run_concept_method(self.id, role_players_req)
+        from grakn.service.Session.util import ResponseReader
+        from grakn.service.Session.Concept import ConceptFactory
         return ResponseReader.ResponseReader.iter_res_to_iterator(
                 self._tx_service,
                 method_response.relation_rolePlayers_iter.id,

--- a/client_python/grakn/service/Session/TransactionService.py
+++ b/client_python/grakn/service/Session/TransactionService.py
@@ -18,7 +18,7 @@
 #
 
 import queue
-from typing import Type
+import six
 
 from grakn.service.Session.util.RequestBuilder import RequestBuilder
 import grakn.service.Session.util.ResponseReader as ResponseReader # for circular import issue
@@ -27,7 +27,7 @@ from grakn.exception.GraknError import GraknError
 
 class TransactionService(object):
 
-    def __init__(self, keyspace, tx_type: enums.TxType, credentials, transaction_endpoint):
+    def __init__(self, keyspace, tx_type, credentials, transaction_endpoint):
         self.keyspace = keyspace
         self.tx_type = tx_type.value
         self.credentials = credentials
@@ -37,17 +37,19 @@ class TransactionService(object):
         # open the transaction with an 'open' message
         open_req = RequestBuilder.open_tx(keyspace, tx_type, credentials)
         self._communicator.send(open_req)
+    __init__.__annotations__ = {'tx_type': enums.TxType}
 
 
     # --- Passthrough targets ---
     # targets of top level Transaction class
 
-    def query(self, query: str, infer=True):
+    def query(self, query, infer=True):
         request = RequestBuilder.query(query, infer=infer)
         # print("Query request: {0}".format(request))
         response = self._communicator.send(request)
         # convert `response` into a python iterator
-        return ResponseReader.ResponseReader.query(self, response.query_iter) 
+        return ResponseReader.ResponseReader.query(self, response.query_iter)
+    query.__annotations__ = {'query': str}
 
     def commit(self):
         request = RequestBuilder.commit()
@@ -59,45 +61,53 @@ class TransactionService(object):
     def is_closed(self):
         return self._communicator._closed
 
-    def get_concept(self, concept_id: str): 
+    def get_concept(self, concept_id):
         request = RequestBuilder.get_concept(concept_id)
         response = self._communicator.send(request)
         return ResponseReader.ResponseReader.get_concept(self, response.getConcept_res)
+    get_concept.__annotations__ = {'concept_id': str}
 
-    def get_schema_concept(self, label: str): 
+    def get_schema_concept(self, label):
         request = RequestBuilder.get_schema_concept(label)
         response = self._communicator.send(request)
         return ResponseReader.ResponseReader.get_schema_concept(self, response.getSchemaConcept_res)
+    get_schema_concept.__annotations__ = {'label': str}
 
-    def get_attributes_by_value(self, attribute_value, data_type: enums.DataType):
+    def get_attributes_by_value(self, attribute_value, data_type):
         request = RequestBuilder.get_attributes_by_value(attribute_value, data_type)
         response = self._communicator.send(request)
         return ResponseReader.ResponseReader.get_attributes_by_value(self, response.getAttributes_iter)
+    get_attributes_by_value.__annotations__ = {'data_type': enums.DataType}
 
-    def put_entity_type(self, label: str):
+    def put_entity_type(self, label):
         request = RequestBuilder.put_entity_type(label)
         response = self._communicator.send(request)
         return ResponseReader.ResponseReader.put_entity_type(self, response.putEntityType_res)
+    put_entity_type.__annotations__ = {'label': str}
 
-    def put_relationship_type(self, label: str):
+    def put_relationship_type(self, label):
         request = RequestBuilder.put_relationship_type(label)
         response = self._communicator.send(request)
         return ResponseReader.ResponseReader.put_relationship_type(self, response.putRelationType_res)
+    put_relationship_type.__annotations__ = {'label': str}
 
-    def put_attribute_type(self, label: str, data_type: enums.DataType):
+    def put_attribute_type(self, label, data_type):
         request = RequestBuilder.put_attribute_type(label, data_type)
         response = self._communicator.send(request)
         return ResponseReader.ResponseReader.put_attribute_type(self, response.putAttributeType_res)
+    put_attribute_type.__annotations__ = {'label': str, 'data_type': enums.DataType}
 
-    def put_role(self, label: str):
+    def put_role(self, label):
         request = RequestBuilder.put_role(label)
         response = self._communicator.send(request)
         return ResponseReader.ResponseReader.put_role(self, response.putRole_res)
+    put_role.__annotations__ = {'label': str}
 
-    def put_rule(self, label: str, when: str, then: str):
+    def put_rule(self, label, when, then):
         request = RequestBuilder.put_rule(label, when, then)
         response = self._communicator.send(request)
         return ResponseReader.ResponseReader.put_rule(self, response.putRule_res)
+    put_rule.__annotations__ = {'label': str, 'when': str, 'then': str}
 
     # --- Transaction Messages ---
 
@@ -108,13 +118,14 @@ class TransactionService(object):
         return response.conceptMethod_res.response
 
 
-    def iterate(self, iterator_id: int):
+    def iterate(self, iterator_id):
         request = RequestBuilder.next_iter(iterator_id)
         response = self._communicator.send(request)
-        return response.iterate_res 
+        return response.iterate_res
+    iterate.__annotations__ = {'iterator_id': int}
 
 
-class Communicator(object):
+class Communicator(six.Iterator):
     """ An iterator and interface for GRPC stream """
 
     def __init__(self, grpc_stream_constructor):

--- a/client_python/grakn/service/Session/util/ResponseReader.py
+++ b/client_python/grakn/service/Session/util/ResponseReader.py
@@ -19,6 +19,7 @@
 
 import abc
 import datetime
+import six
 from grakn.service.Session.util import enums
 from grakn.service.Session.Concept import ConceptFactory
 from grakn.exception.GraknError import GraknError 
@@ -135,8 +136,9 @@ class Explanation(object):
 class Answer(object):
     """ Top level answer, provides interface """
 
-    def __init__(self, explanation: Explanation):
+    def __init__(self, explanation):
         self._explanation = explanation
+    __init__.__annotations__ = {'explanation': Explanation}
 
     @abc.abstractmethod
     def get(self): 
@@ -158,7 +160,7 @@ class Answer(object):
 class AnswerGroup(Answer):
 
     def __init__(self, owner_concept, answer_list, explanation):
-        super().__init__(explanation)
+        super(AnswerGroup, self).__init__(explanation)
         self._owner_concept = owner_concept
         self._answer_list = answer_list
 
@@ -176,7 +178,7 @@ class AnswerGroup(Answer):
 class ConceptMap(Answer):
 
     def __init__(self, concept_map, explanations):
-        super().__init__(explanations)
+        super(ConceptMap, self).__init__(explanations)
         self._concept_map = concept_map 
 
     def get(self, var=None):
@@ -209,9 +211,10 @@ class ConceptMap(Answer):
 
 class ConceptList(Answer):
 
-    def __init__(self, concept_id_list, explanation: Explanation):
-        super().__init__(explanation)
+    def __init__(self, concept_id_list, explanation):
+        super(ConceptList, self).__init__(explanation)
         self._concept_id_list = concept_id_list
+    __init__.__annotations__ = {'explanation': Explanation}
 
     def get(self):
         """ Get this ConceptList """
@@ -223,9 +226,10 @@ class ConceptList(Answer):
 
 class ConceptSet(Answer):
 
-    def __init__(self, concept_id_set, explanation: Explanation):
-        super().__init__(explanation)
+    def __init__(self, concept_id_set, explanation):
+        super(ConceptSet, self).__init__(explanation)
         self._concept_id_set = concept_id_set
+    __init__.__annotations__ = {'explanation': Explanation}
 
     def get(self):
         """ Get this ConceptSet """
@@ -237,9 +241,10 @@ class ConceptSet(Answer):
 
 class ConceptSetMeasure(ConceptSet):
 
-    def __init__(self, concept_id_set, number, explanation: Explanation):
-        super().__init__(concept_id_set, explanation)
+    def __init__(self, concept_id_set, number, explanation):
+        super(ConceptSetMeasure, self).__init__(concept_id_set, explanation)
         self._measurement = number
+    __init__.__annotations__ = {'explanation': Explanation}
 
     def measurement(self):
         return self._measurement
@@ -247,9 +252,10 @@ class ConceptSetMeasure(ConceptSet):
 
 class Value(Answer):
 
-    def __init__(self, number, explanation: Explanation):
-        super().__init__(explanation)
+    def __init__(self, number, explanation):
+        super(Value, self).__init__(explanation)
         self._number = number
+    __init__.__annotations__ = {'explanation': Explanation}
 
     def get(self):
         """ Get this Value object """
@@ -350,7 +356,7 @@ class AnswerConverter(object):
 
 
 
-class ResponseIterator(object):
+class ResponseIterator(six.Iterator):
     """ Retrieves next value in the Grakn response iterator """
 
     def __init__(self, tx_service , iterator_id, iter_resp_converter):

--- a/client_python/setup.py
+++ b/client_python/setup.py
@@ -14,6 +14,6 @@ setup(
     author_email='community@grakn.ai',
     url='https://github.com/graknlabs/grakn/tree/master/client-python',
     keywords=['grakn', 'database', 'graph', 'knowledgebase', 'knowledge-engineering'],
-    python_requires='>=3.6.0',
+    python_requires='>=2.7',
     install_requires=['grpcio', 'protobuf']
 )

--- a/client_python/tests/integration/base.py
+++ b/client_python/tests/integration/base.py
@@ -1,0 +1,53 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+from unittest import TestCase
+from datetime import datetime
+from forbiddenfruit import curse
+
+import six
+
+class DummyContextManager(object):
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self, *args, **kwargs):
+        pass
+
+    def __exit__(self, *args, **kwargs):
+        pass
+
+
+class test_Base(TestCase):
+    """ Sets up DB for use in tests """
+
+    @classmethod
+    def setUpClass(cls):
+        super(test_Base, cls).setUpClass()
+
+        def _datetime_to_timestamp(self):
+            epoch = datetime(1970, 1, 1)
+            diff = self - epoch
+            return int(diff.total_seconds())
+
+        if six.PY2:
+            print 'Patching datetime.timestamp for PY2'
+            print 'Patching unittest.TestCase.subTest for PY2'
+            curse(datetime, 'timestamp', _datetime_to_timestamp)
+            curse(TestCase, 'subTest', DummyContextManager)

--- a/client_python/tests/integration/test_concept.py
+++ b/client_python/tests/integration/test_concept.py
@@ -23,17 +23,18 @@ import datetime
 from grakn.exception.GraknError import GraknError
 
 
-# run-once per testing
+from tests.integration.base import test_Base
+
 inst = grakn.Grakn("localhost:48555")
 session = inst.session("testkeyspace")
 
-class test_Base(unittest.TestCase):
+class test_concept_Base(test_Base):
     """ Sets up DB for use in tests """
 
     @classmethod
     def setUpClass(cls):
         """ Make sure we have some sort of schema and data in DB, only done once """
-        super(test_Base, cls).setUpClass()
+        super(test_concept_Base, cls).setUpClass()
 
         # temp tx to set up DB, don"t save it
         tx = session.transaction(grakn.TxType.WRITE)
@@ -56,7 +57,7 @@ class test_Base(unittest.TestCase):
 
 
 
-class test_Concept(test_Base):
+class test_Concept(test_concept_Base):
     """ Test methods available on all Concepts """
 
     def test_delete_schema_types(self):
@@ -107,7 +108,7 @@ class test_Concept(test_Base):
         self.assertTrue(age.is_attribute())
         self.assertFalse(age.is_relationship())
 
-class test_SchemaConcept(test_Base):
+class test_SchemaConcept(test_concept_Base):
     """ Test methods available on all SchemaConcepts """
     
     def test_set_label(self):
@@ -177,7 +178,7 @@ class test_SchemaConcept(test_Base):
 
 
 
-class test_Type(test_Base):
+class test_Type(test_concept_Base):
     """ Tests concept API of things common to Type objects """
 
     def test_is_abstract(self):
@@ -272,7 +273,7 @@ class test_Type(test_Base):
             self.assertEqual(len(keys), 0)
 
 
-class test_EntityType(test_Base):
+class test_EntityType(test_concept_Base):
 
     def test_create(self):
         person_type = self.tx.get_schema_concept("person")
@@ -280,7 +281,7 @@ class test_EntityType(test_Base):
         self.assertTrue(person.is_entity())
 
 
-class test_AttributeType(test_Base):
+class test_AttributeType(test_concept_Base):
 
     def test_create(self):
         str_attr_type = self.tx.put_attribute_type("firstname", grakn.DataType.STRING)
@@ -337,7 +338,7 @@ class test_AttributeType(test_Base):
         self.assertEqual(regex, "(good|bad)-dog")
 
 
-class test_RelationshipType(test_Base):
+class test_RelationshipType(test_concept_Base):
 
     def test_create(self):
         rel_type = self.tx.put_relationship_type("owner")
@@ -369,7 +370,7 @@ class test_RelationshipType(test_Base):
             self.assertEqual(roles[0].base_type, "ROLE")
 
 
-class test_Rule(test_Base):
+class test_Rule(test_concept_Base):
 
     def test_when_then(self):
         """ Test get valid  when/then """
@@ -388,7 +389,7 @@ class test_Rule(test_Base):
         self.assertIsNone(rule.get_then())
 
 
-class test_Role(test_Base):
+class test_Role(test_concept_Base):
 
     def test_relationships(self):
         """ Test retrieving relationships of a role """
@@ -414,7 +415,7 @@ class test_Role(test_Base):
         self.assertEqual(entity_types[0].label(), "person")
 
 
-class test_Thing(test_Base):
+class test_Thing(test_concept_Base):
 
     def test_is_inferred(self):
         person_type = self.tx.get_schema_concept("person")
@@ -555,7 +556,7 @@ class test_Thing(test_Base):
         self.assertEqual(len(empty_keys), 0)
 
 
-class test_Attribute(test_Base):
+class test_Attribute(test_concept_Base):
 
     def test_value(self):
         """ Get attribute value """
@@ -612,7 +613,7 @@ class test_Attribute(test_Base):
         self.assertTrue(person.id in labels and animal.id in labels)
 
 
-class test_Relationship(test_Base):
+class test_Relationship(test_concept_Base):
 
     def test_role_players_2_roles_1_player(self):
         """ Test role_players_map and role_players with 2 roles and 1 player each """

--- a/client_python/tests/integration/test_grakn.py
+++ b/client_python/tests/integration/test_grakn.py
@@ -22,8 +22,10 @@ import grakn
 from grakn.exception.GraknError import GraknError
 from grakn.service.Session.util.ResponseReader import Answer, Value, ConceptList, ConceptSet, ConceptSetMeasure, AnswerGroup
 
+from tests.integration.base import test_Base
 
-class test_PreDbSetup(unittest.TestCase):
+
+class test_grakn_PreDbSetup(test_Base):
     """ Tests Database interactions *before* anything needs to be inserted/created """
 
     # --- Test grakn client instantiation for one URI ---
@@ -93,13 +95,13 @@ class test_PreDbSetup(unittest.TestCase):
 inst = grakn.Grakn('localhost:48555')
 session = inst.session('testkeyspace')
 
-class test_Base(unittest.TestCase):
+class test_grakn_Base(test_Base):
     """ Sets up DB for use in tests """
 
     @classmethod
     def setUpClass(cls):
         """ Make sure we have some sort of schema and data in DB, only done once """
-        super(test_Base, cls).setUpClass()
+        super(test_grakn_Base, cls).setUpClass()
         # shared grakn instances and session for API testing 
 
         # temp tx to set up DB, don't save it
@@ -124,7 +126,7 @@ class test_Base(unittest.TestCase):
 
 
 
-class test_Transaction(test_Base):
+class test_Transaction(test_grakn_Base):
     """ Class for testing transaction methods, eg query, put attribute type... """
 
     # --- query tests ---

--- a/client_python/tests/integration/test_keyspace.py
+++ b/client_python/tests/integration/test_keyspace.py
@@ -19,10 +19,11 @@
 
 import unittest
 import grakn
+from tests.integration.base import test_Base
 
 client = grakn.Grakn("localhost:48555")
 
-class test_Keyspace(unittest.TestCase):
+class test_Keyspace(test_Base):
 
    def test_retrieve_delete(self):
        """ Test retrieving and deleting a specific keyspace """

--- a/dependencies/compilers/dependencies.bzl
+++ b/dependencies/compilers/dependencies.bzl
@@ -40,9 +40,9 @@ def grpc_dependencies():
 def python_dependencies():
     native.git_repository(
         name = "io_bazel_rules_python",
-        remote = "https://github.com/graknlabs/rules_python.git",
-        commit = "abd475a72ae6a098cc9f859eb435dddd992bc884",
-        sha256 = "fe468b9396ef5c933679e1a5d846f777d0ea4731927df2149e5a01b328afd9b6"
+        remote = "https://github.com/bazelbuild/rules_python.git",
+        commit = "8b5d0683a7d878b28fffe464779c8a53659fc645",
+        sha256 = "8b32d2dbb0b0dca02e0410da81499eef8ff051dad167d6931a92579e3b2a1d48"
     )
 
 

--- a/dependencies/pypi/requirements.txt
+++ b/dependencies/pypi/requirements.txt
@@ -1,2 +1,4 @@
-grpcio==1.13.0
-protobuf==3.6.0
+grpcio==1.16.0
+protobuf==3.6.1
+six==1.11.0
+forbiddenfruit==0.1.2


### PR DESCRIPTION
# Why is this PR needed?

To make `client_python` library and tests with Python2

# What does the PR do?

Adapts `client_python` so it works with both Python 2 and Python 3

# Does it break backwards compatibility?

Nope, it adds it instead

# List of future improvements not on this PR

—