### PR TITLE
Fix client-nodejs-e2e and workbase-e2e (client-python still pending)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,8 +121,8 @@ jobs:
         - *install_bazel
         - run: bazel build //:distribution --sandbox_debug
         - run: unzip bazel-genfiles/dist/grakn-core-all.zip -d bazel-genfiles/dist/
-        - run: nohup bazel-genfiles/dist/grakn-core-all/grakn-core server start
-        - run: bazel-genfiles/dist/grakn-core-all/grakn-core console -f `pwd`/test-end-to-end/test-fixtures/basic-genealogy.gql -k gene
+        - run: nohup bazel-genfiles/dist/grakn-core-all/grakn server start
+        - run: bazel-genfiles/dist/grakn-core-all/grakn console -f `pwd`/test-end-to-end/test-fixtures/basic-genealogy.gql -k gene
         - run: bazel test //client-nodejs:test-integration --test_output=streamed
 
   client-python-e2e:
@@ -162,8 +162,8 @@ jobs:
         - run: sudo apt install libnss3 libasound2 libgconf-2-4 -y
         - run: bazel build //:distribution --sandbox_debug
         - run: unzip bazel-genfiles/dist/grakn-core-all.zip -d bazel-genfiles/dist/
-        - run: nohup bazel-genfiles/dist/grakn-core-all/grakn-core server start
-        - run: bazel-genfiles/dist/grakn-core-all/grakn-core console -f `pwd`/test-end-to-end/test-fixtures/basic-genealogy.gql -k gene
+        - run: nohup bazel-genfiles/dist/grakn-core-all/grakn server start
+        - run: bazel-genfiles/dist/grakn-core-all/grakn console -f `pwd`/test-end-to-end/test-fixtures/basic-genealogy.gql -k gene
         - run: cd workbase && npm install
         - run: Xvfb :99 &
         - run: export DISPLAY=:99


### PR DESCRIPTION
# Why is this PR needed?
Updated client-nodejs-e2e and workbase-e2e test. They still refer to the bash script as `grakn-core` instead of `grakn` 

# What does the PR do?

# Does it break backwards compatibility?

# List of future improvements not on this PR
