### PR TITLE
Fix failing python build by replacing 'import queue' with 'import six.moves.queue'

### DIFF
--- a/client_python/grakn/service/Session/TransactionService.py
+++ b/client_python/grakn/service/Session/TransactionService.py
@@ -17,8 +17,9 @@
 # under the License.
 #
 
-import queue
 import six
+from six.moves import queue
+
 
 from grakn.service.Session.util.RequestBuilder import RequestBuilder
 import grakn.service.Session.util.ResponseReader as ResponseReader # for circular import issue


### PR DESCRIPTION
# Why is this PR needed?
Fix failing build by replacing 'import queue' with 'import six.moves.queue'

# What does the PR do?

# Does it break backwards compatibility?

# List of future improvements not on this PR
