### PR TITLE
enum34 dependency

### DIFF
--- a/client_python/BUILD
+++ b/client_python/BUILD
@@ -43,6 +43,7 @@ py_library(
         requirement("protobuf"),
         requirement("grpcio"),
         requirement("six"),
+        requirement("enum34")
     ]
 )
 

--- a/dependencies/pypi/requirements.txt
+++ b/dependencies/pypi/requirements.txt
@@ -2,3 +2,4 @@ grpcio==1.16.0
 protobuf==3.6.1
 six==1.11.0
 forbiddenfruit==0.1.2
+enum34==1.1.6


### PR DESCRIPTION
# Why is this PR needed?

Fix tests on CircleCI

# What does the PR do?

Includes missing dependency on `enum34` for `client-python`

# Does it break backwards compatibility?

Nope

# List of future improvements not on this PR

—