### PR TITLE
Integrate unused_deps tool

### DIFF
--- a/dependencies/tools/BUILD
+++ b/dependencies/tools/BUILD
@@ -28,3 +28,12 @@ java_binary(
     visibility = ["//visibility:public"],
     runtime_deps = [":bazel-deps-jar"],
 )
+
+sh_binary(
+    name = "unused-deps",
+    srcs = ["unused-deps.sh"],
+    data = [
+        "@unused_deps//file",
+        "@unused_deps_osx//file",
+    ],
+)

--- a/dependencies/tools/dependencies.bzl
+++ b/dependencies/tools/dependencies.bzl
@@ -50,8 +50,15 @@ def tools_dependencies():
     native.http_file(
         name = "unused_deps",
         executable = True,
-        sha256 = "686f8943610e1a5e3d196e2209dcb35f463c3b583a056dd8ae355acdc2a089d8",
-        urls = ["https://github.com/bazelbuild/buildtools/releases/download/0.11.1/unused_deps"],
+        sha256 = "f6e8b5b3d95709964790473eddbd9ef552f4f9bd7d4136181aaf94594ee405cb",
+        urls = ["https://github.com/bazelbuild/buildtools/releases/download/0.17.2/unused_deps"],
+    )
+
+    native.http_file(
+        name = "unused_deps_osx",
+        executable = True,
+        sha256 = "bce2a7064836d426cc59005ba75778216bda7bb06a997d58444598dac8b85ebc",
+        urls = ["https://github.com/bazelbuild/buildtools/releases/download/0.17.2/unused_deps.osx"],
     )
 
     native.http_file(

--- a/dependencies/tools/unused-deps.sh
+++ b/dependencies/tools/unused-deps.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Wrapper script for running unused_deps
+
+platform=$(uname)
+
+pwd
+
+if [ "$platform" == "Darwin" ]; then
+    UNUSED_DEPS_BINARY=$(pwd)/external/unused_deps_osx/file/unused_deps.osx
+elif [ "$platform" == "Linux" ]; then
+    UNUSED_DEPS_BINARY=$(pwd)/external/unused_deps/file/unused_deps
+else
+    echo "unused_deps does not have a binary for $platform"
+    exit 1
+fi
+
+cd $BUILD_WORKSPACE_DIRECTORY
+$UNUSED_DEPS_BINARY $*


### PR DESCRIPTION
# Why is this PR needed?

To make use of `unused_deps` tool

# What does the PR do?

Integrates `unused_deps` tool so we're able to run it as `bazel run //dependencies/tools:unused_deps`

# Does it break backwards compatibility?

No

# List of future improvements not on this PR

Other binaries from `//dependencies/tools/...` are not sh-wrapped yet